### PR TITLE
[WIP]Reuse dedent_string function in rb_ruby_ripper_dedent_string function

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -252,6 +252,17 @@ ripper_parser_set_debug_output(VALUE self, VALUE output)
     return output;
 }
 
+static int
+ripper_parser_dedent_string(struct parser_params *p, VALUE string, int width)
+{
+    int col;
+    rb_parser_string_t *str;
+    str = rb_str_to_parser_string(p, string);
+    col = rb_ruby_ripper_dedent_string(p, str, width);
+    rb_str_replace(string, rb_str_new_parser_string(str));
+    return col;
+}
+
 #ifdef UNIVERSAL_PARSER
 struct dedent_string_arg {
     struct parser_params *p;
@@ -267,7 +278,7 @@ parser_dedent_string0(VALUE a)
 
     StringValue(arg->input);
     wid = NUM2UINT(arg->width);
-    col = rb_ruby_ripper_dedent_string(arg->p, arg->input, wid);
+    col = ripper_parser_dedent_string(arg->p, arg->input, wid);
     return INT2NUM(col);
 }
 
@@ -312,7 +323,7 @@ parser_dedent_string(VALUE self, VALUE input, VALUE width)
 
     StringValue(input);
     wid = NUM2UINT(width);
-    col = rb_ruby_ripper_dedent_string(0, input, wid);
+    col = ripper_parser_dedent_string(0, input, wid);
     return INT2NUM(col);
 }
 #endif

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -104,7 +104,7 @@ VALUE rb_ruby_parser_ruby_sourcefile_string(rb_parser_t *p);
 int rb_ruby_parser_ruby_sourceline(rb_parser_t *p);
 int rb_ruby_parser_lex_state(rb_parser_t *p);
 void rb_ruby_ripper_parse0(rb_parser_t *p);
-int rb_ruby_ripper_dedent_string(rb_parser_t *p, VALUE string, int width);
+int rb_ruby_ripper_dedent_string(rb_parser_t *p, rb_parser_string_t *string, int width);
 int rb_ruby_ripper_initialized_p(rb_parser_t *p);
 void rb_ruby_ripper_parser_initialize(rb_parser_t *p);
 long rb_ruby_ripper_column(rb_parser_t *p);

--- a/parse.y
+++ b/parse.y
@@ -15868,23 +15868,9 @@ rb_ruby_ripper_parse0(rb_parser_t *p)
 }
 
 int
-rb_ruby_ripper_dedent_string(rb_parser_t *p, VALUE string, int width)
+rb_ruby_ripper_dedent_string(rb_parser_t *p, rb_parser_string_t *string, int width)
 {
-    char *str;
-    long len;
-    int i;
-
-    RSTRING_GETMEM(string, str, len);
-    i = dedent_string_column(str, len, width);
-    if (!i) return 0;
-
-    rb_str_modify(string);
-    str = RSTRING_PTR(string);
-    if (RSTRING_LEN(string) != len)
-        rb_fatal("literal string changed: %+"PRIsVALUE, string);
-    MEMMOVE(str, str + i, char, len - i);
-    rb_str_set_len(string, len - i);
-    return i;
+    return dedent_string(p, string, width);
 }
 
 int

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -371,8 +371,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .str_catf = rb_str_catf,
     .str_cat_cstr = rb_str_cat_cstr,
-    .str_modify = rb_str_modify,
-    .str_set_len = rb_str_set_len,
     .str_cat = rb_str_cat,
     .str_resize = rb_str_resize,
     .str_new = rb_str_new,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1205,8 +1205,6 @@ typedef struct rb_parser_config_struct {
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
     VALUE (*str_catf)(VALUE str, const char *format, ...);
     VALUE (*str_cat_cstr)(VALUE str, const char *ptr);
-    void (*str_modify)(VALUE str);
-    void (*str_set_len)(VALUE str, long len);
     VALUE (*str_cat)(VALUE str, const char *ptr, long len);
     VALUE (*str_resize)(VALUE str, long len);
     VALUE (*str_new)(const char *ptr, long len);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -26,10 +26,6 @@
 #define rb_strlen_lit(str) (sizeof(str "") - 1)
 #undef FIXNUM_MAX
 #define FIXNUM_MAX (LONG_MAX / 2)
-#undef RSTRING_GETMEM
-#define RSTRING_GETMEM(str, ptrvar, lenvar) \
-    ((ptrvar) = RSTRING_PTR(str),           \
-     (lenvar) = RSTRING_LEN(str))
 
 /* parser_st */
 #define st_table parser_st_table
@@ -119,8 +115,6 @@
 #define rb_str_catf                       p->config->str_catf
 #undef rb_str_cat_cstr
 #define rb_str_cat_cstr                   p->config->str_cat_cstr
-#define rb_str_modify                     p->config->str_modify
-#define rb_str_set_len                    p->config->str_set_len
 #define rb_str_cat                        p->config->str_cat
 #define rb_str_resize                     p->config->str_resize
 #undef rb_str_new


### PR DESCRIPTION
This change is reduce Ruby C API dependency for Universal Parser. Reuse dedent_string functions in rb_ruby_ripper_dedent_string functions and remove dependencies on rb_str_modify and rb_str_set_len from the parser.